### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+libbrahe (1.3.2-8) UNRELEASED; urgency=medium
+
+  * Apply multi-arch hints.
+    + libbrahe-1.3-3: Add Multi-Arch: same.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 12 May 2021 04:05:57 -0000
+
 libbrahe (1.3.2-7) unstable; urgency=medium
 
   * Remove use of autotools-dev from debhelper usage

--- a/debian/control
+++ b/debian/control
@@ -30,6 +30,7 @@ Description: heterogeneous C library of numeric functions
 Package: libbrahe-1.3-3
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Multi-Arch: same
 Description: heterogeneous C library of numeric functions
  This library provides:
  .
@@ -43,4 +44,3 @@ Description: heterogeneous C library of numeric functions
  .
  This library is also used by libevocosm, which is in turn the 
  foundation for Acovea, used to determine optimal compiler optimizations
-


### PR DESCRIPTION


Apply hints suggested by the multi-arch hinter.



These changes were suggested on https://wiki.debian.org/MultiArch/Hints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/multiarch-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/libbrahe/4c1bfc2d-cc5c-4847-b85b-c63c07d0755b.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/d3/38d4998501032aa1a60517446936d3ee04be13.debug
    -rw-r--r--  root/root   /usr/share/doc/libbrahe-dev/html/doxygen.svg
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/49/03f57296bf5ed5c7f2d537a88bfd4c57b3882e.debug
    -rw-r--r--  root/root   /usr/share/doc/libbrahe-dev/html/doxygen.png
### Control files of package libbrahe-1.3-3: lines which differ (wdiff format)
* {+Multi-Arch: same+}
### Control files of package libbrahe-1.3-3-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-4903f57296bf5ed5c7f2d537a88bfd4c57b3882e-] {+d338d4998501032aa1a60517446936d3ee04be13+}
* {+Multi-Arch: same+}

No differences were encountered between the control files of package \*\*libbrahe-dev\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/4c1bfc2d-cc5c-4847-b85b-c63c07d0755b/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/4c1bfc2d-cc5c-4847-b85b-c63c07d0755b/diffoscope)).
